### PR TITLE
Remove deploy entry from .travis.yaml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,3 @@ script:
     - coverage run --source="." manage.py test api
 after_success:
     - codecov
-deploy:
-  provider: heroku
-  api_key:
-    secure: $KEY_HEROKU
-


### PR DESCRIPTION
The project has being deployed from GitHub integration, there's no need to do it again from Travis CI.