### PR TITLE
Adjust Payment Serializer

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -38,10 +38,6 @@ class LoanSerializer(serializers.ModelSerializer):
 
 
 class PaymentSerializer(serializers.ModelSerializer):
-    """
-    Serializer for Payment model
-    """
-
     class Meta:
         model = Payment
         fields = "__all__"


### PR DESCRIPTION
- Remove unnecessary docstring
A method for converting the payment id into a hash won't be necessary, since we are using UUID as primary key in the Payment Model.

related to #28 
close #31 
